### PR TITLE
chore: Switch to self-hosted GitHub agents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
       - name: Get secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@8fa210559ab2cc62e7b12d3bb9cba19dbc862c11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [github-hosted-ubuntu-x64-small , macos-latest]
+        os: [ubuntu-x64-small, macos-latest]
         java: ['8', '11', '17', '21']
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Updated GitHub workflow files to use self-hosted agents instead of GitHub-hosted runners